### PR TITLE
Load content packs from folders

### DIFF
--- a/src/main/java/api/contentpack/ContentPack.java
+++ b/src/main/java/api/contentpack/ContentPack.java
@@ -41,6 +41,12 @@ public class ContentPack {
     private Collection<IFile> subFiles;
     private final Path basePath;
 
+    /**
+     * Creates a zipped pack
+     * @param contentPackFileIn
+     * @param packInfoObject
+     * @param zipFileSize
+     */
     public ContentPack(File contentPackFileIn, PackInfoObject packInfoObject, long zipFileSize) {
         this.contentPackFile = contentPackFileIn;
         this.packInfoObject = packInfoObject;
@@ -49,6 +55,13 @@ public class ContentPack {
         isZipped = true;
     }
 
+    /**
+     * Creates a zipped pack, with the given icon
+     * @param iconStream
+     * @param contentPackFileIn
+     * @param packInfoObject
+     * @param zipFileSize
+     */
     public ContentPack(InputStream iconStream, File contentPackFileIn, PackInfoObject packInfoObject, long zipFileSize) {
         this(contentPackFileIn, packInfoObject, zipFileSize);
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
@@ -60,6 +73,20 @@ public class ContentPack {
         });
     }
 
+    /**
+     * Creates a folder-based pack
+     */
+    public ContentPack(Path contentPackFolder, PackInfoObject packInfoObject) {
+        this.contentPackFile = contentPackFolder.toFile();
+        this.basePath = contentPackFolder;
+        this.packInfoObject = packInfoObject;
+        this.zipFileSize = 0L;
+        isZipped = false;
+    }
+
+    /**
+     * Creates a folder-based pack, with the given icon
+     */
     public ContentPack(InputStream iconStream, Path contentPackFolder, PackInfoObject packInfoObject) {
         this(contentPackFolder, packInfoObject);
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
@@ -69,14 +96,6 @@ public class ContentPack {
                 e.printStackTrace();
             }
         });
-    }
-
-    public ContentPack(Path contentPackFolder, PackInfoObject packInfoObject) {
-        this.contentPackFile = contentPackFolder.toFile();
-        this.basePath = contentPackFolder;
-        this.packInfoObject = packInfoObject;
-        this.zipFileSize = 0L;
-        isZipped = false;
     }
 
     private ZipFile getBackingZip() throws IOException {

--- a/src/main/java/api/contentpack/PackManager.java
+++ b/src/main/java/api/contentpack/PackManager.java
@@ -68,6 +68,9 @@ public class PackManager {
         }
     }
 
+    /**
+     * Walks down the contentpacks/ folder hierarchy to find pack present as folders
+     */
     private void loadUnzippedPacks() {
         // load zipped packs
         try (Stream<Path> walk = Files.walk(this.contentPackPath)) {
@@ -76,10 +79,9 @@ public class PackManager {
                     .collect(Collectors.toList())
                     .forEach(pack -> {
                         Path basePath = pack.toPath();
-                        try(Stream<Path> subFiles = Files.walk(basePath)) {
-                            parseAndAdd(createUnzippedContentPack(basePath, subFiles.map(basePath::relativize).collect(Collectors.toList())));
-                        }
-                        catch (Exception e) {
+                        try {
+                            parseAndAdd(createUnzippedContentPack(basePath));
+                        } catch (FileNotFoundException e) {
                             e.printStackTrace();
                         }
                     });
@@ -88,7 +90,14 @@ public class PackManager {
         }
     }
 
-    private ContentPack createUnzippedContentPack(Path basePath, List<Path> subFiles) throws FileNotFoundException {
+    /**
+     * Create {@link ContentPack} based on a folder
+     *
+     * @param basePath base folder path
+     * @return
+     * @throws IOException
+     */
+    private ContentPack createUnzippedContentPack(Path basePath) throws FileNotFoundException {
         Path actualPath = basePath.resolve("content.pack");
         File actualFile = actualPath.toFile();
 
@@ -110,6 +119,10 @@ public class PackManager {
         }
     }
 
+    /**
+     * Parses the data inside a content pack and adds it to the list of loaded packs
+     * @param contentPack
+     */
     private void parseAndAdd(ContentPack contentPack) {
         if (contentPack != null) {
             if (contentPack.getPackInfo().getNuwaDataVersion() == this.dataVersion) {
@@ -126,6 +139,9 @@ public class PackManager {
         }
     }
 
+    /**
+     * Walks down the contentpacks/ folder hierarchy to find pack present as zip files
+     */
     private void loadZippedPacks() {
         // load zipped packs
         try (Stream<Path> walk = Files.walk(this.contentPackPath)) {

--- a/src/main/java/api/contentpack/data/IPackData.java
+++ b/src/main/java/api/contentpack/data/IPackData.java
@@ -19,13 +19,11 @@ public interface IPackData extends IData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
-     * @param packManagerIn The {@link PackManager} instance
+     *  @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
-    void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn);
+    void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn);
 
     /**
      * Use {@link PackManager}

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ArmorMaterialData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ArmorMaterialData.java
@@ -36,11 +36,10 @@ public class ArmorMaterialData implements IPackData {
      *
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         ArmorMaterialObject armorMaterialObject = packManagerIn.getGson().fromJson(readerIn, ArmorMaterialObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), armorMaterialObject.getRegistryName());
         armorMaterialTypes.add(new ArmorMaterialType(armorMaterialObject).setRegistryName(registryName));

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BiomeData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BiomeData.java
@@ -46,11 +46,10 @@ public class BiomeData implements IPackData {
      *
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         BiomeObject biomeObject = packManagerIn.getGson().fromJson(readerIn, BiomeObject.class);
 
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), biomeObject.getRegistryName());

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BlockEventData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BlockEventData.java
@@ -34,14 +34,13 @@ public class BlockEventData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         BlockEventObject blockEventObject = packManagerIn.getGson().fromJson(readerIn, BlockEventObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), blockEventObject.getRegistryName());
         this.blockEventTypes.add(new BlockEventType(blockEventObject).setRegistryName(registryName));

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BlocksData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/BlocksData.java
@@ -46,14 +46,13 @@ public class BlocksData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         BlockObject blocksObject = packManagerIn.getGson().fromJson(readerIn, BlockObject.class);
 
         AtomicReference<IJsonBlock> parsedBlock = new AtomicReference<>();
@@ -107,7 +106,7 @@ public class BlocksData implements IPackData {
                         if (NuwaRegistries.ITEM_GROUP.getValue(parsedItemGroup) != null) {
                             parsedBlock.get().setItemGroup(NuwaRegistries.ITEM_GROUP.getValue(parsedItemGroup).getItemGroup());
                         } else {
-                            packManagerIn.throwItemGroupWarn(contentPackIn, zipFileIn, getEntryFolder(), parsedItemGroup);
+                            packManagerIn.throwItemGroupWarn(contentPackIn, getEntryFolder(), parsedItemGroup);
                         }
                     } else {
                         parsedBlock.get().setItemGroup(ItemGroup.MISC);

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/EffectsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/EffectsData.java
@@ -35,14 +35,13 @@ public class EffectsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         EffectObject effectObject = packManagerIn.getGson().fromJson(readerIn, EffectObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), effectObject.getRegistryName());
         JsonEffect parsedEffect = new JsonEffect(effectObject.getEffectType(), effectObject.getLiquidColor(), registryName, effectObject.isInstant());

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/FluidsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/FluidsData.java
@@ -32,14 +32,13 @@ public class FluidsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
 
     }
 

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ItemGroupData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ItemGroupData.java
@@ -36,14 +36,13 @@ public class ItemGroupData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         ItemGroupObject itemGroupObject = packManagerIn.getGson().fromJson(readerIn, ItemGroupObject.class);
 
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), itemGroupObject.getRegistryName());

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ItemsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ItemsData.java
@@ -51,14 +51,13 @@ public class ItemsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
 
         ItemObject itemsObject = packManagerIn.getGson().fromJson(readerIn, ItemObject.class);
 
@@ -83,7 +82,7 @@ public class ItemsData implements IPackData {
                     if (NuwaRegistries.ITEM_GROUP.getValue(parsedItemGroup) != null) {
                         properties.group(NuwaRegistries.ITEM_GROUP.getValue(parsedItemGroup).getItemGroup());
                     } else {
-                        packManagerIn.throwItemGroupWarn(contentPackIn, zipFileIn, getEntryFolder(), parsedItemGroup);
+                        packManagerIn.throwItemGroupWarn(contentPackIn, getEntryFolder(), parsedItemGroup);
                     }
                 } else {
                     properties.group(ItemGroup.MISC);

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/OresGenerationData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/OresGenerationData.java
@@ -38,15 +38,14 @@ public class OresGenerationData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     //TODO Check if it's a correct check of nonnull/empty and list contain object from other.
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         OresGenerationObject generationObject = packManagerIn.getGson().fromJson(readerIn, OresGenerationObject.class);
 
         if (generationObject.getOreBlock() != null) {

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/PaintingsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/PaintingsData.java
@@ -34,14 +34,13 @@ public class PaintingsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         PaintingObject paintingObject = packManagerIn.getGson().fromJson(readerIn, PaintingObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), paintingObject.getRegistryName());
         this.paintingTypes.add(new JsonPainting(paintingObject.getWidth(), paintingObject.getHeight(), registryName));

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/PotionsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/PotionsData.java
@@ -35,14 +35,13 @@ public class PotionsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         PotionObject potionObject = packManagerIn.getGson().fromJson(readerIn, PotionObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), potionObject.getRegistryName());
         String baseName = potionObject.getBaseName() != null ? potionObject.getBaseName() : potionObject.getRegistryName();

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/SoundsData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/SoundsData.java
@@ -33,14 +33,13 @@ public class SoundsData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         SoundObject soundObject = packManagerIn.getGson().fromJson(readerIn, SoundObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), soundObject.getRegistryName());
         SoundEvent soundEvent = new SoundEvent(registryName);

--- a/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ToolMaterialData.java
+++ b/src/main/java/fr/zeamateis/nuwa/contentpack/common/data/ToolMaterialData.java
@@ -32,14 +32,13 @@ public class ToolMaterialData implements IPackData {
     /**
      * Use {@link PackManager}, {@link ContentPack}, {@link ZipFile} and {@link InputStreamReader}
      * instances to parse datas from Content Pack zip file
-     *
+     *  @param zipFileIn     The {@link ZipFile} instance
      * @param packManagerIn The {@link PackManager} instance
      * @param contentPackIn The {@link ContentPack} instance
-     * @param zipFileIn     The {@link ZipFile} instance
      * @param readerIn      The {@link InputStreamReader} instance
      */
     @Override
-    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, ZipFile zipFileIn, InputStreamReader readerIn) {
+    public void parseData(PackManager packManagerIn, ContentPack contentPackIn, InputStreamReader readerIn) {
         ToolMaterialObject toolMaterialObject = packManagerIn.getGson().fromJson(readerIn, ToolMaterialObject.class);
         ResourceLocation registryName = new ResourceLocation(contentPackIn.getNamespace(), toolMaterialObject.getRegistryName());
         toolMaterialTypes.add(new ToolMaterialType(toolMaterialObject).setRegistryName(registryName));

--- a/src/main/java/fr/zeamateis/nuwa/io/DiskFile.java
+++ b/src/main/java/fr/zeamateis/nuwa/io/DiskFile.java
@@ -1,0 +1,36 @@
+package fr.zeamateis.nuwa.io;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ *
+ * @author jglrxavpok
+ */
+public class DiskFile implements IFile {
+
+    private File file;
+    private Path relativePath;
+
+    public DiskFile(File file, Path relativePath) {
+        this.file = file;
+        this.relativePath = relativePath;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    @Override
+    public String getName() {
+        return relativePath.toString().replace(File.separator, "/");
+    }
+
+    @Override
+    public InputStream getInputStream() throws FileNotFoundException {
+        return new FileInputStream(file);
+    }
+}

--- a/src/main/java/fr/zeamateis/nuwa/io/DiskFile.java
+++ b/src/main/java/fr/zeamateis/nuwa/io/DiskFile.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 /**
- *
+ * File present on disk
  * @author jglrxavpok
  */
 public class DiskFile implements IFile {

--- a/src/main/java/fr/zeamateis/nuwa/io/IFile.java
+++ b/src/main/java/fr/zeamateis/nuwa/io/IFile.java
@@ -1,0 +1,25 @@
+package fr.zeamateis.nuwa.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Represents an abstract file, either a file on the disk, or inside a zip file
+ * @author jglrxavpok
+ */
+public interface IFile {
+
+    /**
+     * Returns the simple name of the file
+     * @return
+     */
+    String getName();
+
+    /**
+     * Returns a **new** InputStream to read from this file
+     * @return
+     * @throws IOException if an error occurred
+     */
+    InputStream getInputStream() throws IOException;
+
+}

--- a/src/main/java/fr/zeamateis/nuwa/io/ZipEntryFile.java
+++ b/src/main/java/fr/zeamateis/nuwa/io/ZipEntryFile.java
@@ -1,0 +1,30 @@
+package fr.zeamateis.nuwa.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ *
+ * @author jglrxavpok
+ */
+public class ZipEntryFile implements IFile {
+    private final ZipFile archive;
+    private final ZipEntry entry;
+
+    public ZipEntryFile(ZipFile archive, ZipEntry entry) {
+        this.archive = archive;
+        this.entry = entry;
+    }
+
+    @Override
+    public String getName() {
+        return entry.getName();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return archive.getInputStream(entry);
+    }
+}

--- a/src/main/java/fr/zeamateis/nuwa/io/ZipEntryFile.java
+++ b/src/main/java/fr/zeamateis/nuwa/io/ZipEntryFile.java
@@ -6,7 +6,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 /**
- *
+ * File present inside a zip file
  * @author jglrxavpok
  */
 public class ZipEntryFile implements IFile {


### PR DESCRIPTION
Like resource packs, allow content packs to be loaded from folders instead of requiring a zip file. (Speeds up debug and development of packs)